### PR TITLE
Fix flaky test in TestConvertAvroToParquet by recreating map

### DIFF
--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -55,6 +55,7 @@ import java.util.Map;
 
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -230,7 +231,7 @@ public class TestConvertAvroToParquet {
         // Map
         int[] values = {firstRecord.getGroup("mymap",0).getGroup("key_value",0).getInteger("value", 0), firstRecord.getGroup("mymap",0).getGroup("key_value",1).getInteger("value", 0)};
         Arrays.sort(values);
-        assertEquals(Arrays.toString(values), "[1, 2]");
+        assertArrayEquals(values, new int[]{1, 2});
 
         // Fixed
         assertEquals(firstRecord.getString("myfixed",0), "A");

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -52,10 +52,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.HashMap;
 
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -229,9 +229,13 @@ public class TestConvertAvroToParquet {
         assertEquals(firstRecord.getGroup("myarray",0).getGroup("list",1).getInteger("element", 0), 2);
 
         // Map
-        int[] values = {firstRecord.getGroup("mymap",0).getGroup("key_value",0).getInteger("value", 0), firstRecord.getGroup("mymap",0).getGroup("key_value",1).getInteger("value", 0)};
-        Arrays.sort(values);
-        assertArrayEquals(values, new int[]{1, 2});
+        Map mymap = new HashMap();
+        mymap.put(firstRecord.getGroup("mymap",0).getGroup("key_value",0).getString("key", 0), firstRecord.getGroup("mymap",0).getGroup("key_value",0).getInteger("value", 0));
+        mymap.put(firstRecord.getGroup("mymap",0).getGroup("key_value",1).getString("key", 0), firstRecord.getGroup("mymap",0).getGroup("key_value",1).getInteger("value", 0));
+        Map correctMap = new HashMap();
+        correctMap.put("a", 1);
+        correctMap.put("b", 2);
+        assertEquals(mymap, correctMap);
 
         // Fixed
         assertEquals(firstRecord.getString("myfixed",0), "A");

--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/src/test/java/org/apache/nifi/processors/parquet/TestConvertAvroToParquet.java
@@ -228,8 +228,9 @@ public class TestConvertAvroToParquet {
         assertEquals(firstRecord.getGroup("myarray",0).getGroup("list",1).getInteger("element", 0), 2);
 
         // Map
-        assertEquals(firstRecord.getGroup("mymap",0).getGroup("key_value",0).getInteger("value", 0), 1);
-        assertEquals(firstRecord.getGroup("mymap",0).getGroup("key_value",1).getInteger("value", 0), 2);
+        int[] values = {firstRecord.getGroup("mymap",0).getGroup("key_value",0).getInteger("value", 0), firstRecord.getGroup("mymap",0).getGroup("key_value",1).getInteger("value", 0)};
+        Arrays.sort(values);
+        assertEquals(Arrays.toString(values), "[1, 2]");
 
         // Fixed
         assertEquals(firstRecord.getString("myfixed",0), "A");


### PR DESCRIPTION
The test `org.apache.nifi.processors.parquet.TestConvertAvroToParquet.testData`fails when running the Nondex tool (`edu.illinois:nondex-maven-plugin:1.1.2:nondex`). The root cause is that `.getGroup("key_value",0)` and `.getGroup("key_value",1)` are nondeterministic. The order in `"key_value"`  is not guaranteed, so the test fails by asserting a specific value for each index.

The fix for this is to first declare a temporary HashMap in the test, then recreate the original map by getting the keys and values from it one by one and store them in the temporary map, and finally use `assertEquals()` to compare the temporary map with a expected correct map. With the proposed fix, the test is fully fixed without interrupting the source code.